### PR TITLE
improve handling of sources

### DIFF
--- a/templates/conanfile.py.jinja
+++ b/templates/conanfile.py.jinja
@@ -1,7 +1,10 @@
 import os.path
 from conan import ConanFile
 from conan.tools.build import check_min_cppstd
-from conan.tools.files import copy
+from conan.tools.files import (
+    copy,
+    rmdir,
+)
 from conan.tools.scm import Git
 
 class Boost{{ project.name.title() }}Recipe(ConanFile):
@@ -20,6 +23,7 @@ class Boost{{ project.name.title() }}Recipe(ConanFile):
     default_options = {'shared': False}
     {%- elif project.cxxstd is defined -%}
     settings = 'compiler'
+    no_copy_source = True
     {%- endif %}
 
     package_type = {% if project.headeronly -%}
@@ -54,6 +58,7 @@ class Boost{{ project.name.title() }}Recipe(ConanFile):
         git = Git(self)
         data = self.conan_data['sources'][self.version]
         git.fetch_commit(data['url'], data['commit'])
+        rmdir(self, '.git')
 
     {% if project.headeronly -%}
     def build(self):


### PR DESCRIPTION
* do not copy sources when "building" header-only packages
* do not store .git directory in sources